### PR TITLE
fix: update method receiver name

### DIFF
--- a/internal/provider/instances_v2.go
+++ b/internal/provider/instances_v2.go
@@ -24,10 +24,10 @@ type InstancesV2 struct {
 
 // InstanceExists checks whether the provided Kubernetes node exists as instance
 // in Oxide.
-func (c *InstancesV2) InstanceExists(ctx context.Context, node *v1.Node) (bool, error) {
+func (i *InstancesV2) InstanceExists(ctx context.Context, node *v1.Node) (bool, error) {
 	instanceID := strings.TrimPrefix(node.Spec.ProviderID, "oxide://")
 
-	if _, err := c.client.InstanceView(ctx, oxide.InstanceViewParams{
+	if _, err := i.client.InstanceView(ctx, oxide.InstanceViewParams{
 		Instance: oxide.NameOrId(instanceID),
 	}); err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
@@ -42,7 +42,7 @@ func (c *InstancesV2) InstanceExists(ctx context.Context, node *v1.Node) (bool, 
 
 // InstanceMetadata populates the metadata for the provided node, notably
 // setting its provider ID.
-func (c *InstancesV2) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloudprovider.InstanceMetadata, error) {
+func (i *InstancesV2) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloudprovider.InstanceMetadata, error) {
 	var (
 		err        error
 		instance   *oxide.Instance
@@ -52,15 +52,15 @@ func (c *InstancesV2) InstanceMetadata(ctx context.Context, node *v1.Node) (*clo
 	if node.Spec.ProviderID != "" {
 		instanceID = strings.TrimPrefix(node.Spec.ProviderID, "oxide://")
 
-		instance, err = c.client.InstanceView(ctx, oxide.InstanceViewParams{
+		instance, err = i.client.InstanceView(ctx, oxide.InstanceViewParams{
 			Instance: oxide.NameOrId(instanceID),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed viewing oxide instance by id: %v", err)
 		}
 	} else {
-		instance, err = c.client.InstanceView(ctx, oxide.InstanceViewParams{
-			Project:  oxide.NameOrId(c.project),
+		instance, err = i.client.InstanceView(ctx, oxide.InstanceViewParams{
+			Project:  oxide.NameOrId(i.project),
 			Instance: oxide.NameOrId(node.GetName()),
 		})
 		if err != nil {
@@ -70,14 +70,14 @@ func (c *InstancesV2) InstanceMetadata(ctx context.Context, node *v1.Node) (*clo
 		instanceID = instance.Id
 	}
 
-	nics, err := c.client.InstanceNetworkInterfaceList(ctx, oxide.InstanceNetworkInterfaceListParams{
+	nics, err := i.client.InstanceNetworkInterfaceList(ctx, oxide.InstanceNetworkInterfaceListParams{
 		Instance: oxide.NameOrId(instanceID),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed listing instance network interfaces: %v", err)
 	}
 
-	externalIPs, err := c.client.InstanceExternalIpList(ctx, oxide.InstanceExternalIpListParams{
+	externalIPs, err := i.client.InstanceExternalIpList(ctx, oxide.InstanceExternalIpListParams{
 		Instance: oxide.NameOrId(instanceID),
 	})
 	if err != nil {
@@ -116,10 +116,10 @@ func (c *InstancesV2) InstanceMetadata(ctx context.Context, node *v1.Node) (*clo
 }
 
 // InstanceShutdown checks whether the provided node is shut down in Oxide.
-func (c *InstancesV2) InstanceShutdown(ctx context.Context, node *v1.Node) (bool, error) {
+func (i *InstancesV2) InstanceShutdown(ctx context.Context, node *v1.Node) (bool, error) {
 	instanceID := strings.TrimPrefix(node.Spec.ProviderID, "oxide://")
 
-	instance, err := c.client.InstanceView(ctx, oxide.InstanceViewParams{
+	instance, err := i.client.InstanceView(ctx, oxide.InstanceViewParams{
 		Instance: oxide.NameOrId(instanceID),
 	})
 	if err != nil {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -37,28 +37,28 @@ type Oxide struct {
 
 // Initialize creates the Oxide and Kubernetes clients and spawns any additional
 // controllers, if necessary.
-func (c *Oxide) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
+func (o *Oxide) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
 	kubernetesClient, err := clientBuilder.Client(Name)
 	if err != nil {
 		klog.Fatalf("failed to create kubernetes client: %v", err)
 		return
 	}
-	c.k8sClient = kubernetesClient
+	o.k8sClient = kubernetesClient
 
 	oxideClient, err := oxide.NewClient(nil)
 	if err != nil {
 		klog.Fatalf("failed to create oxide client: %v", err)
 		return
 	}
-	c.client = oxideClient
+	o.client = oxideClient
 
-	c.project = os.Getenv("OXIDE_PROJECT")
+	o.project = os.Getenv("OXIDE_PROJECT")
 
 	klog.InfoS("initialized cloud provider", "type", "oxide")
 }
 
 // ProviderName returns the name of this cloud provider.
-func (c *Oxide) ProviderName() string {
+func (o *Oxide) ProviderName() string {
 	return Name
 }
 
@@ -70,7 +70,7 @@ func (c *Oxide) ProviderName() string {
 // it's expected that a Kubernetes cluster on Oxide is deployed in its own VPC
 // and does not share resources with other Kubernetes clusters. This may become
 // supported in the future when Oxide has resource tags or labels.
-func (c *Oxide) HasClusterID() bool {
+func (o *Oxide) HasClusterID() bool {
 	return false
 }
 
@@ -78,41 +78,41 @@ func (c *Oxide) HasClusterID() bool {
 // Controller Manager to manage multiple Kubernetes clusters but the modern
 // idiom is to run a single Cloud Controller Manager per Kubernetes cluster,
 // making this irrelevant.
-func (c *Oxide) Clusters() (cloudprovider.Clusters, bool) {
+func (o *Oxide) Clusters() (cloudprovider.Clusters, bool) {
 	return nil, false
 }
 
 // Instances is purposefully unimplemented. Use [Oxide.InstancesV2].
-func (c *Oxide) Instances() (cloudprovider.Instances, bool) {
+func (o *Oxide) Instances() (cloudprovider.Instances, bool) {
 	return nil, false
 }
 
 // InstancesV2 returns an implementation of [cloudprovider.InstancesV2]
 // that provides functionality to initialize Kubernetes nodes, provide their
 // metadata, and determine whether they exists to facilitate cleanup.
-func (c *Oxide) InstancesV2() (cloudprovider.InstancesV2, bool) {
+func (o *Oxide) InstancesV2() (cloudprovider.InstancesV2, bool) {
 	return &InstancesV2{
-		client:    c.client,
-		project:   c.project,
-		k8sClient: c.k8sClient,
+		client:    o.client,
+		project:   o.project,
+		k8sClient: o.k8sClient,
 	}, true
 }
 
 // LoadBalancer is currently unimplemented. This may be implemented in the
 // future.
-func (c *Oxide) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
+func (o *Oxide) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 	return nil, false
 }
 
 // Routes is purposefully unimplemented. It is expected that the Kubernetes
 // cluster uses a third-party CNI instead of this controller. This may be
 // implemented in the future.
-func (c *Oxide) Routes() (cloudprovider.Routes, bool) {
+func (o *Oxide) Routes() (cloudprovider.Routes, bool) {
 	return nil, false
 }
 
 // Zones is purposefully unimplemented. Zone and region information is retrieved
 // from [InstancesV2.InstanceMetadata] instead.
-func (c *Oxide) Zones() (cloudprovider.Zones, bool) {
+func (o *Oxide) Zones() (cloudprovider.Zones, bool) {
 	return nil, false
 }


### PR DESCRIPTION
Updated the method receiver name to use the Go idiom of the first letter of the corresponding type.