### PR TITLE
fix: use the correct version format

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Build Container Image
-        run: make image-build
+        run: make build
 
       - name: Run Tests
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 0.1.0-$(GIT_COMMIT_SHORT)
+VERSION ?= v0.1.0
 GO_CONTAINER_IMAGE ?= docker.io/golang:1.25.3
 
 CONTAINER_RUNTIME ?= $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -11,7 +11,7 @@ GIT_COMMIT_SHORT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unkn
 # Container image configuration.
 IMAGE_REGISTRY ?= ghcr.io/oxidecomputer
 IMAGE_NAME ?= oxide-cloud-controller-manager
-IMAGE_TAG ?= $(VERSION)
+IMAGE_TAG ?= $(patsubst v%,%,$(VERSION))-$(GIT_COMMIT_SHORT)
 IMAGE_FULL ?= $(if $(IMAGE_REGISTRY),$(IMAGE_REGISTRY)/)$(IMAGE_NAME):$(IMAGE_TAG)
 
 .PHONY: test
@@ -25,8 +25,8 @@ test:
 		.
 	$(CONTAINER_RUNTIME) run --rm $(IMAGE_NAME)-builder:$(IMAGE_TAG) go test -v ./...
 
-.PHONY: image-build
-image-build:
+.PHONY: build
+build:
 	@echo "Building container image: $(IMAGE_FULL)"
 	$(CONTAINER_RUNTIME) build \
 		--build-arg GO_CONTAINER_IMAGE=$(GO_CONTAINER_IMAGE) \
@@ -34,8 +34,8 @@ image-build:
 		-t $(IMAGE_FULL) \
 		.
 
-.PHONY: image-push
-image-push:
+.PHONY: push
+push:
 	@if [ -z "$(IMAGE_REGISTRY)" ]; then \
 		echo "Error: IMAGE_REGISTRY must be set to push images"; \
 		echo "Example: make image-push IMAGE_REGISTRY=ghcr.io/oxidecomputer"; \


### PR DESCRIPTION
The Kubernetes `k8s.io/component-base/version` package requires the `gitVersion` variable to be valid `vX.Y.Z` SemVer. Updated the version in the `Makefile` to be compatible. Also updated a few `Makefile` target names.