### PR TITLE
misc: update `oxide.go`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.3
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/oxidecomputer/oxide.go v0.7.0
+	github.com/oxidecomputer/oxide.go v0.8.0
 	k8s.io/api v0.35.1
 	k8s.io/apimachinery v0.35.1
 	k8s.io/client-go v0.35.1
@@ -24,7 +24,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
@@ -62,7 +62,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,9 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bFY/oTyCes=
@@ -139,12 +140,13 @@ github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
 github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6uXf3k=
-github.com/oxidecomputer/oxide.go v0.7.0 h1:ZRxH3vSgwZys/dsQthphW4o57xp0BivUCkND18b5nr4=
-github.com/oxidecomputer/oxide.go v0.7.0/go.mod h1:e/Azkl4nFUrsdsJ113siW/ZNUQkiG539e4i7a6GEcD8=
+github.com/oxidecomputer/oxide.go v0.8.0 h1:ASdHKty2hr3gA/T+9a0gbeKTp45bx3V8gE2Q8mJuQoI=
+github.com/oxidecomputer/oxide.go v0.8.0/go.mod h1:pL9BcSmHMyhR8Utxr2AcV6wG59OIrcSV3dNduIzGGdo=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=

--- a/internal/provider/instances_v2.go
+++ b/internal/provider/instances_v2.go
@@ -94,21 +94,50 @@ func (i *InstancesV2) InstanceMetadata(ctx context.Context, node *v1.Node) (*clo
 	})
 
 	for _, nic := range nics.Items {
-		nodeAddresses = append(nodeAddresses, v1.NodeAddress{
-			Type:    v1.NodeInternalIP,
-			Address: nic.Ip,
-		})
+		if v4, ok := nic.IpStack.AsV4(); ok {
+			nodeAddresses = append(nodeAddresses, v1.NodeAddress{
+				Type:    v1.NodeInternalIP,
+				Address: v4.Value.Ip,
+			})
+		}
+
+		if v6, ok := nic.IpStack.AsV6(); ok {
+			nodeAddresses = append(nodeAddresses, v1.NodeAddress{
+				Type:    v1.NodeInternalIP,
+				Address: v6.Value.Ip,
+			})
+		}
+
+		if dualStack, ok := nic.IpStack.AsDualStack(); ok {
+			nodeAddresses = append(nodeAddresses, v1.NodeAddress{
+				Type:    v1.NodeInternalIP,
+				Address: dualStack.Value.V4.Ip,
+			})
+			nodeAddresses = append(nodeAddresses, v1.NodeAddress{
+				Type:    v1.NodeInternalIP,
+				Address: dualStack.Value.V6.Ip,
+			})
+		}
 	}
 
 	for _, externalIP := range externalIPs.Items {
-		if externalIP.Kind == "snat" {
+		if _, ok := externalIP.AsSnat(); ok {
 			continue
 		}
 
-		nodeAddresses = append(nodeAddresses, v1.NodeAddress{
-			Type:    v1.NodeExternalIP,
-			Address: externalIP.Ip,
-		})
+		if ephemeral, ok := externalIP.AsEphemeral(); ok {
+			nodeAddresses = append(nodeAddresses, v1.NodeAddress{
+				Type:    v1.NodeExternalIP,
+				Address: ephemeral.Ip,
+			})
+		}
+
+		if floating, ok := externalIP.AsFloating(); ok {
+			nodeAddresses = append(nodeAddresses, v1.NodeAddress{
+				Type:    v1.NodeExternalIP,
+				Address: floating.Ip,
+			})
+		}
 	}
 
 	return &cloudprovider.InstanceMetadata{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -51,7 +51,7 @@ func (o *Oxide) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, 
 	}
 	o.k8sClient = kubernetesClient
 
-	oxideClient, err := oxide.NewClient(nil)
+	oxideClient, err := oxide.NewClient()
 	if err != nil {
 		klog.Fatalf("failed to create oxide client: %v", err)
 	}


### PR DESCRIPTION
Updated `oxide.go` to be compatible with release 18.

Relates to SSE-145.