### PR TITLE
Refactor instance lookup to skip an unnecessary api call.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/oxidecomputer/oxide.go v0.9.0
+	github.com/oxidecomputer/oxide.go v0.9.1-0.20260420200835-b6f489e52089
 	k8s.io/api v0.35.4
 	k8s.io/apimachinery v0.35.4
 	k8s.io/client-go v0.35.4

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
 github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6uXf3k=
-github.com/oxidecomputer/oxide.go v0.9.0 h1:BwwRLsXomk43q+qQLWgksu8FhJJMftp85XQT5CDDCuw=
-github.com/oxidecomputer/oxide.go v0.9.0/go.mod h1:I36KqKtLBuKdi9HeXRwP2FHc7s98+HvYgFozvfyKnpE=
+github.com/oxidecomputer/oxide.go v0.9.1-0.20260420200835-b6f489e52089 h1:9jEQTD3At8j8Y5mhns5Bc2bJdUwRpfRQOEeOYtoZyRc=
+github.com/oxidecomputer/oxide.go v0.9.1-0.20260420200835-b6f489e52089/go.mod h1:6KXHuYsXMOR1DS3uRE+wI6DPVQnS16tEDkj8miqXQcY=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/provider/instances_v2.go
+++ b/internal/provider/instances_v2.go
@@ -6,8 +6,8 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/oxidecomputer/oxide.go/oxide"
@@ -44,11 +44,11 @@ func (i *InstancesV2) InstanceExists(ctx context.Context, node *v1.Node) (bool, 
 	if _, err := i.client.InstanceView(ctx, oxide.InstanceViewParams{
 		Instance: oxide.NameOrId(instanceID),
 	}); err != nil {
-		if strings.Contains(err.Error(), "NotFound") {
+		if errors.Is(err, oxide.ErrObjectNotFound) {
 			return false, nil
 		}
 
-		return false, fmt.Errorf("failed viewing oxide instance %s: %v", instanceID, err)
+		return false, fmt.Errorf("failed viewing oxide instance %s: %w", instanceID, err)
 	}
 
 	return true, nil
@@ -63,35 +63,27 @@ func (i *InstancesV2) InstanceMetadata(
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	// Get the instance ID, either from the provider ID or by looking up by name.
-	instanceID, err := i.getInstanceID(ctx, node)
+	// Get the instance, either from the provider ID or by looking up by name.
+	instance, err := i.getInstance(ctx, node)
 	if err != nil {
 		return nil, err
-	}
-
-	// Retrieve the instance details.
-	instance, err := i.client.InstanceView(ctx, oxide.InstanceViewParams{
-		Instance: oxide.NameOrId(instanceID),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed viewing oxide instance: %v", err)
 	}
 
 	nics, err := i.client.InstanceNetworkInterfaceList(
 		ctx,
 		oxide.InstanceNetworkInterfaceListParams{
-			Instance: oxide.NameOrId(instanceID),
+			Instance: oxide.NameOrId(instance.Id),
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed listing instance network interfaces: %v", err)
+		return nil, fmt.Errorf("failed listing instance network interfaces: %w", err)
 	}
 
 	externalIPs, err := i.client.InstanceExternalIpList(ctx, oxide.InstanceExternalIpListParams{
-		Instance: oxide.NameOrId(instanceID),
+		Instance: oxide.NameOrId(instance.Id),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed listing instance external ips: %v", err)
+		return nil, fmt.Errorf("failed listing instance external ips: %w", err)
 	}
 
 	nodeAddresses := make([]v1.NodeAddress, 0)
@@ -148,29 +140,35 @@ func (i *InstancesV2) InstanceMetadata(
 	}
 
 	return &cloudprovider.InstanceMetadata{
-		ProviderID:    NewProviderID(instanceID),
+		ProviderID:    NewProviderID(instance.Id),
 		InstanceType:  fmt.Sprintf("%d-%d", instance.Ncpus, instance.Memory/gibibyte),
 		NodeAddresses: nodeAddresses,
 	}, nil
 }
 
-// getInstanceID retrieves the instance ID either from the node's provider ID
+// getInstance retrieves the instance either from the node's provider ID
 // or by looking up the instance by name.
-func (i *InstancesV2) getInstanceID(ctx context.Context, node *v1.Node) (string, error) {
+func (i *InstancesV2) getInstance(ctx context.Context, node *v1.Node) (*oxide.Instance, error) {
+	var params oxide.InstanceViewParams
 	if node.Spec.ProviderID != "" {
-		return InstanceIDFromProviderID(node.Spec.ProviderID)
+		instanceID, err := InstanceIDFromProviderID(node.Spec.ProviderID)
+		if err != nil {
+			return nil, fmt.Errorf("failed parsing provider id %s: %w", node.Spec.ProviderID, err)
+		}
+		params = oxide.InstanceViewParams{Instance: oxide.NameOrId(instanceID)}
+	} else {
+		params = oxide.InstanceViewParams{
+			Project:  oxide.NameOrId(i.project),
+			Instance: oxide.NameOrId(node.GetName()),
+		}
 	}
 
-	// If no provider ID is set, look up the instance by name.
-	instance, err := i.client.InstanceView(ctx, oxide.InstanceViewParams{
-		Project:  oxide.NameOrId(i.project),
-		Instance: oxide.NameOrId(node.GetName()),
-	})
+	instance, err := i.client.InstanceView(ctx, params)
 	if err != nil {
-		return "", fmt.Errorf("failed viewing oxide instance by name: %v", err)
+		return nil, fmt.Errorf("failed viewing oxide instance: %w", err)
 	}
 
-	return instance.Id, nil
+	return instance, nil
 }
 
 // InstanceShutdown checks whether the provided node is shut down in Oxide.
@@ -187,7 +185,7 @@ func (i *InstancesV2) InstanceShutdown(ctx context.Context, node *v1.Node) (bool
 		Instance: oxide.NameOrId(instanceID),
 	})
 	if err != nil {
-		return false, fmt.Errorf("failed viewing oxide instance %s: %v", instanceID, err)
+		return false, fmt.Errorf("failed viewing oxide instance %s: %w", instanceID, err)
 	}
 
 	return instance.RunState == oxide.InstanceStateStopped, nil

--- a/internal/provider/load_balancer.go
+++ b/internal/provider/load_balancer.go
@@ -65,7 +65,7 @@ func (l *LoadBalancer) GetLoadBalancer(
 		},
 	)
 	if err != nil {
-		if strings.Contains(err.Error(), "NotFound") {
+		if errors.Is(err, oxide.ErrObjectNotFound) {
 			return nil, false, nil
 		}
 		return nil, false, fmt.Errorf(
@@ -250,7 +250,7 @@ func (l *LoadBalancer) EnsureLoadBalancerDeleted(
 		},
 	)
 	if err != nil {
-		if strings.Contains(err.Error(), "NotFound") {
+		if errors.Is(err, oxide.ErrObjectNotFound) {
 			return nil
 		}
 		return fmt.Errorf(
@@ -347,7 +347,7 @@ func (l *LoadBalancer) ensureLoadBalancer(
 		},
 	)
 	if err != nil {
-		if !strings.Contains(err.Error(), "NotFound") {
+		if !errors.Is(err, oxide.ErrObjectNotFound) {
 			return nil, fmt.Errorf(
 				"failed viewing floating ip %s: %w", name, err,
 			)


### PR DESCRIPTION
Rather than potentially looking up the instance by name and then a second time by id, ensure that we only check the api once. We also bump oxide.go to latest to fix an enum bug, and move to the new error code handling provided by the sdk.

Replaces #215.