### PR TITLE
Cache go tool dependencies.

### DIFF
--- a/.github/workflows/lint-fmt.yaml
+++ b/.github/workflows/lint-fmt.yaml
@@ -16,6 +16,17 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache-dependency-path: |
+            go.sum
+            tools/go.sum
+
+      - name: Cache golangci-lint analysis
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/golangci-lint
+          key: golangci-lint-${{ runner.os }}-${{ hashFiles('tools/go.sum', '.golangci.yaml', 'go.mod') }}
+          restore-keys: |
+            golangci-lint-${{ runner.os }}-
 
       - name: Lint
         run: make lint
@@ -31,6 +42,17 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache-dependency-path: |
+            go.sum
+            tools/go.sum
+
+      - name: Cache golangci-lint analysis
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/golangci-lint
+          key: golangci-lint-${{ runner.os }}-${{ hashFiles('tools/go.sum', '.golangci.yaml', 'go.mod') }}
+          restore-keys: |
+            golangci-lint-${{ runner.os }}-
 
       - name: Format
         run: make fmt

--- a/.github/workflows/manifest.yaml
+++ b/.github/workflows/manifest.yaml
@@ -16,6 +16,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache-dependency-path: |
+            go.sum
+            tools/go.sum
 
       - name: Generate Manifest
         run: make manifest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,6 +86,9 @@ jobs:
     - uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
+        cache-dependency-path: |
+          go.sum
+          tools/go.sum
 
     - uses: docker/login-action@v3
       with:


### PR DESCRIPTION
Configure the setup-go action to cache dependencies for both go.sum and tools/go.sum. Otherwise, we'll download all tool dependencies fresh on every run.