### PR TITLE
fix: support name look-up on InstanceExists() and InstanceShutdown() if no providerID set

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,6 +6,7 @@ linters:
   enable:
     - godoclint
     - unparam
+    - goheader
   disable:
     - errcheck
   settings:
@@ -16,6 +17,11 @@ linters:
       options:
         max-len:
           length: 100
+    goheader:
+      template: |-
+        This Source Code Form is subject to the terms of the Mozilla Public
+        License, v. 2.0. If a copy of the MPL was not distributed with this
+        file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 formatters:
   enable:

--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,12 @@ helm-push: helm-package
 fmt:
 	@ echo "+ Formatting Go code..."
 	@ go tool -modfile tools/go.mod golangci-lint fmt
+	@ go tool -modfile tools/go.mod golangci-lint run --enable-only=goheader --fix
 
 .PHONY: lint
 lint:
 	@ echo "+ Running Go linters..."
 	@ go tool -modfile tools/go.mod golangci-lint run
+
+.PHONY: dev
+dev: fmt lint test

--- a/internal/provider/instances_v2.go
+++ b/internal/provider/instances_v2.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/oxidecomputer/oxide.go/oxide"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
 	cloudprovider "k8s.io/cloud-provider"
 )
 
@@ -21,13 +20,17 @@ var _ cloudprovider.InstancesV2 = (*InstancesV2)(nil)
 // gibibyte is the number of bytes in a gibibyte.
 const gibibyte = 1024 * 1024 * 1024
 
+type oxideInstanceClient interface {
+	InstanceNetworkInterfaceList(context.Context, oxide.InstanceNetworkInterfaceListParams) (*oxide.InstanceNetworkInterfaceResultsPage, error)
+	InstanceExternalIpList(context.Context, oxide.InstanceExternalIpListParams) (*oxide.ExternalIpResultsPage, error)
+	InstanceView(context.Context, oxide.InstanceViewParams) (*oxide.Instance, error)
+}
+
 // InstancesV2 implements [cloudprovider.InstancesV2] to provide Oxide specific
 // instance functionality.
 type InstancesV2 struct {
-	client  *oxide.Client
+	client  oxideInstanceClient
 	project string
-
-	k8sClient kubernetes.Interface
 }
 
 // InstanceExists checks whether the provided Kubernetes node exists as an instance
@@ -45,7 +48,6 @@ func (i *InstancesV2) InstanceExists(ctx context.Context, node *v1.Node) (bool, 
 		}
 		return false, err
 	}
-
 	return true, nil
 }
 

--- a/internal/provider/instances_v2.go
+++ b/internal/provider/instances_v2.go
@@ -30,25 +30,20 @@ type InstancesV2 struct {
 	k8sClient kubernetes.Interface
 }
 
-// InstanceExists checks whether the provided Kubernetes node exists as instance
-// in Oxide.
+// InstanceExists checks whether the provided Kubernetes node exists as an instance
+// in Oxide. the Cloud Node Lifecycle Controller uses this information to determine
+// if it can delete the Node object.
 func (i *InstancesV2) InstanceExists(ctx context.Context, node *v1.Node) (bool, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	instanceID, err := InstanceIDFromProviderID(node.Spec.ProviderID)
+	// Get the instance, either from the provider ID or by looking up by name.
+	_, err := i.getInstance(ctx, node)
 	if err != nil {
-		return false, fmt.Errorf("failed retrieving instance id from provider id: %w", err)
-	}
-
-	if _, err := i.client.InstanceView(ctx, oxide.InstanceViewParams{
-		Instance: oxide.NameOrId(instanceID),
-	}); err != nil {
 		if errors.Is(err, oxide.ErrObjectNotFound) {
 			return false, nil
 		}
-
-		return false, fmt.Errorf("failed viewing oxide instance %s: %w", instanceID, err)
+		return false, err
 	}
 
 	return true, nil
@@ -146,6 +141,25 @@ func (i *InstancesV2) InstanceMetadata(
 	}, nil
 }
 
+// InstanceShutdown checks whether the provided node is shut down in Oxide.
+// The cloud node lifecycle controller uses this to determine if the
+// node.cloudprovider.kubernetes.io/shutdown:NoSchedule taint should
+// be applied to the Node object.
+func (i *InstancesV2) InstanceShutdown(ctx context.Context, node *v1.Node) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	// Get the instance, either from the provider ID or by looking up by name.
+	instance, err := i.getInstance(ctx, node)
+	if err != nil {
+		if errors.Is(err, oxide.ErrObjectNotFound) {
+			return true, nil
+		}
+		return false, err
+	}
+	return instance.RunState == oxide.InstanceStateStopped, nil
+}
+
 // getInstance retrieves the instance either from the node's provider ID
 // or by looking up the instance by name.
 func (i *InstancesV2) getInstance(ctx context.Context, node *v1.Node) (*oxide.Instance, error) {
@@ -169,24 +183,4 @@ func (i *InstancesV2) getInstance(ctx context.Context, node *v1.Node) (*oxide.In
 	}
 
 	return instance, nil
-}
-
-// InstanceShutdown checks whether the provided node is shut down in Oxide.
-func (i *InstancesV2) InstanceShutdown(ctx context.Context, node *v1.Node) (bool, error) {
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	instanceID, err := InstanceIDFromProviderID(node.Spec.ProviderID)
-	if err != nil {
-		return false, fmt.Errorf("failed retrieving instance id from provider id: %w", err)
-	}
-
-	instance, err := i.client.InstanceView(ctx, oxide.InstanceViewParams{
-		Instance: oxide.NameOrId(instanceID),
-	})
-	if err != nil {
-		return false, fmt.Errorf("failed viewing oxide instance %s: %w", instanceID, err)
-	}
-
-	return instance.RunState == oxide.InstanceStateStopped, nil
 }

--- a/internal/provider/instances_v2.go
+++ b/internal/provider/instances_v2.go
@@ -34,7 +34,7 @@ type InstancesV2 struct {
 }
 
 // InstanceExists checks whether the provided Kubernetes node exists as an instance
-// in Oxide. the Cloud Node Lifecycle Controller uses this information to determine
+// in Oxide. The cloud node lifecycle controller uses this information to determine
 // if it can delete the Node object.
 func (i *InstancesV2) InstanceExists(ctx context.Context, node *v1.Node) (bool, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -51,8 +51,9 @@ func (i *InstancesV2) InstanceExists(ctx context.Context, node *v1.Node) (bool, 
 	return true, nil
 }
 
-// InstanceMetadata populates the metadata for the provided node, notably
-// setting its provider ID.
+// InstanceMetadata is called by the cloud node controller to initialize nodes with
+// the node.cloudprovider.kubernetes.io/uninitialized:NoSchedule taint. It returns
+// metadata for the provided node, notably its provider ID.
 func (i *InstancesV2) InstanceMetadata(
 	ctx context.Context,
 	node *v1.Node,

--- a/internal/provider/instances_v2.go
+++ b/internal/provider/instances_v2.go
@@ -21,8 +21,14 @@ var _ cloudprovider.InstancesV2 = (*InstancesV2)(nil)
 const gibibyte = 1024 * 1024 * 1024
 
 type oxideInstanceClient interface {
-	InstanceNetworkInterfaceList(context.Context, oxide.InstanceNetworkInterfaceListParams) (*oxide.InstanceNetworkInterfaceResultsPage, error)
-	InstanceExternalIpList(context.Context, oxide.InstanceExternalIpListParams) (*oxide.ExternalIpResultsPage, error)
+	InstanceNetworkInterfaceList(
+		context.Context,
+		oxide.InstanceNetworkInterfaceListParams,
+	) (*oxide.InstanceNetworkInterfaceResultsPage, error)
+	InstanceExternalIpList(
+		context.Context,
+		oxide.InstanceExternalIpListParams,
+	) (*oxide.ExternalIpResultsPage, error)
 	InstanceView(context.Context, oxide.InstanceViewParams) (*oxide.Instance, error)
 }
 

--- a/internal/provider/instances_v2_test.go
+++ b/internal/provider/instances_v2_test.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package provider
 
 import (

--- a/internal/provider/instances_v2_test.go
+++ b/internal/provider/instances_v2_test.go
@@ -167,21 +167,30 @@ func TestShutdown(t *testing.T) {
 	})
 }
 
-func (c *mockOxideClient) InstanceNetworkInterfaceList(context.Context, oxide.InstanceNetworkInterfaceListParams) (*oxide.InstanceNetworkInterfaceResultsPage, error) {
+func (c *mockOxideClient) InstanceNetworkInterfaceList(
+	context.Context,
+	oxide.InstanceNetworkInterfaceListParams,
+) (*oxide.InstanceNetworkInterfaceResultsPage, error) {
 	if c.InstanceNetworkInterfaceListError != nil {
 		return nil, c.InstanceNetworkInterfaceListError
 	}
 	return c.InstanceNetworkInterfaceListOutput, nil
 }
 
-func (c *mockOxideClient) InstanceExternalIpList(context.Context, oxide.InstanceExternalIpListParams) (*oxide.ExternalIpResultsPage, error) {
+func (c *mockOxideClient) InstanceExternalIpList(
+	context.Context,
+	oxide.InstanceExternalIpListParams,
+) (*oxide.ExternalIpResultsPage, error) {
 	if c.InstanceExternalIpListError != nil {
 		return nil, c.InstanceExternalIpListError
 	}
 	return c.InstanceExternalIpListOutput, nil
 }
 
-func (c *mockOxideClient) InstanceView(context.Context, oxide.InstanceViewParams) (*oxide.Instance, error) {
+func (c *mockOxideClient) InstanceView(
+	context.Context,
+	oxide.InstanceViewParams,
+) (*oxide.Instance, error) {
 	if c.InstanceViewError != nil {
 		return nil, c.InstanceViewError
 	}

--- a/internal/provider/instances_v2_test.go
+++ b/internal/provider/instances_v2_test.go
@@ -1,0 +1,189 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/oxidecomputer/oxide.go/oxide"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type mockOxideClient struct {
+	InstanceNetworkInterfaceListOutput *oxide.InstanceNetworkInterfaceResultsPage
+	InstanceNetworkInterfaceListError  error
+
+	InstanceExternalIpListOutput *oxide.ExternalIpResultsPage
+	InstanceExternalIpListError  error
+
+	InstanceViewOutput *oxide.Instance
+	InstanceViewError  error
+}
+
+var (
+	nodeWithoutProviderID = v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+		Spec:       v1.NodeSpec{},
+	}
+	nodeWithProviderID = v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+		Spec: v1.NodeSpec{
+			ProviderID: "oxide://12345678-1234-1234-1234-123456789abc",
+		},
+	}
+	nodeDoesNotExistInOxide = v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-2"},
+		Spec: v1.NodeSpec{
+			ProviderID: "oxide://87654321-1234-1234-1234-123456789abc",
+		},
+	}
+
+	instanceRunning = oxide.Instance{
+		Name:     oxide.Name("node-1"),
+		Id:       "12345678-1234-1234-1234-123456789abc",
+		RunState: oxide.InstanceStateRunning,
+	}
+
+	instanceStopped = oxide.Instance{
+		Name:     oxide.Name("node-1"),
+		Id:       "12345678-1234-1234-1234-123456789abc",
+		RunState: oxide.InstanceStateStopped,
+	}
+)
+
+func TestInstanceExists(t *testing.T) {
+	t.Run("WithProviderID", func(t *testing.T) {
+		instancesV2 := InstancesV2{
+			client: &mockOxideClient{
+				InstanceViewOutput: &instanceRunning,
+			},
+			project: "test",
+		}
+		exists, err := instancesV2.InstanceExists(t.Context(), &nodeWithProviderID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !exists {
+			t.Fatal("expected instance to exist via the Oxide API")
+		}
+	})
+
+	t.Run("NoProviderID", func(t *testing.T) {
+		instancesV2 := InstancesV2{
+			client: &mockOxideClient{
+				InstanceViewOutput: &instanceRunning,
+			},
+			project: "test",
+		}
+		exists, err := instancesV2.InstanceExists(t.Context(), &nodeWithoutProviderID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !exists {
+			t.Fatal("expected instance to exist via the Oxide API")
+		}
+	})
+
+	t.Run("DoesNotExistInOxide", func(t *testing.T) {
+		instancesV2 := InstancesV2{
+			client: &mockOxideClient{
+				InstanceViewError: oxide.ErrObjectNotFound,
+			},
+			project: "test",
+		}
+		exists, err := instancesV2.InstanceExists(t.Context(), &nodeDoesNotExistInOxide)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if exists {
+			t.Fatal("expected instance to NOT exist via the Oxide API")
+		}
+	})
+}
+
+func TestShutdown(t *testing.T) {
+	t.Run("RunningWithProviderID", func(t *testing.T) {
+		instancesV2 := InstancesV2{
+			client: &mockOxideClient{
+				InstanceViewOutput: &instanceRunning,
+			},
+			project: "test",
+		}
+		shutdown, err := instancesV2.InstanceShutdown(t.Context(), &nodeWithProviderID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if shutdown {
+			t.Fatal("expected instance to be running via the Oxide API")
+		}
+	})
+
+	t.Run("RunningNoProviderID", func(t *testing.T) {
+		instancesV2 := InstancesV2{
+			client: &mockOxideClient{
+				InstanceViewOutput: &instanceRunning,
+			},
+			project: "test",
+		}
+		shutdown, err := instancesV2.InstanceShutdown(t.Context(), &nodeWithoutProviderID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if shutdown {
+			t.Fatal("expected instance to be running via the Oxide API")
+		}
+	})
+
+	t.Run("InstanceStopped", func(t *testing.T) {
+		instancesV2 := InstancesV2{
+			client: &mockOxideClient{
+				InstanceViewOutput: &instanceStopped,
+			},
+			project: "test",
+		}
+		shutdown, err := instancesV2.InstanceShutdown(t.Context(), &nodeDoesNotExistInOxide)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !shutdown {
+			t.Fatal("expected instance to be stopped via the Oxide API")
+		}
+	})
+
+	t.Run("DoesNotExistInOxide", func(t *testing.T) {
+		instancesV2 := InstancesV2{
+			client: &mockOxideClient{
+				InstanceViewError: oxide.ErrObjectNotFound,
+			},
+			project: "test",
+		}
+		shutdown, err := instancesV2.InstanceShutdown(t.Context(), &nodeDoesNotExistInOxide)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !shutdown {
+			t.Fatal("expected instance to NOT exist via the Oxide API")
+		}
+	})
+}
+
+func (c *mockOxideClient) InstanceNetworkInterfaceList(context.Context, oxide.InstanceNetworkInterfaceListParams) (*oxide.InstanceNetworkInterfaceResultsPage, error) {
+	if c.InstanceNetworkInterfaceListError != nil {
+		return nil, c.InstanceNetworkInterfaceListError
+	}
+	return c.InstanceNetworkInterfaceListOutput, nil
+}
+
+func (c *mockOxideClient) InstanceExternalIpList(context.Context, oxide.InstanceExternalIpListParams) (*oxide.ExternalIpResultsPage, error) {
+	if c.InstanceExternalIpListError != nil {
+		return nil, c.InstanceExternalIpListError
+	}
+	return c.InstanceExternalIpListOutput, nil
+}
+
+func (c *mockOxideClient) InstanceView(context.Context, oxide.InstanceViewParams) (*oxide.Instance, error) {
+	if c.InstanceViewError != nil {
+		return nil, c.InstanceViewError
+	}
+	return c.InstanceViewOutput, nil
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -104,9 +104,8 @@ func (o *Oxide) Instances() (cloudprovider.Instances, bool) {
 // metadata, and determine whether they exists to facilitate cleanup.
 func (o *Oxide) InstancesV2() (cloudprovider.InstancesV2, bool) {
 	return &InstancesV2{
-		client:    o.client,
-		project:   o.project,
-		k8sClient: o.k8sClient,
+		client:  o.client,
+		project: o.project,
 	}, true
 }
 


### PR DESCRIPTION
## Changes

- Supports a name look-up if providerID is not set rather than erroring in `InstanceExists()` and `InstanceShutdown()`. 
- Adds tests for InstancesV2. 
- Removes unused K8s client in InstancesV2

## Why?

There is a comment on the interface of InstanceV2 saying [providerID and name should be supported](https://github.com/kubernetes/cloud-provider/blob/v0.36.1/cloud.go#L210-L216).

Apart from the interface comment, the edge case where a name look-up helps:

1. A node comes online while CCM is unhealthy due to an update or some other issue. 
2. The node shuts down before CCM becomes healthy. 
3. CCM comes back up, sees the node, but `InstanceMetadata()` and`InstanceExists()` return errors since there is no providerID set.
4. The Node Lifecycle Controller does not automatically delete the node, so it stays there forever (or until a user manually deletes the node). 

Ideally, we should clean-up the node in this case since it in-fact does not exist.  

*NOTE: The name look-up only works if the node is registered with the `Name` of the Oxide instance. This should be pretty standard though. It's more standard to use the `hostname` as the node name of a K8s node, which in most cases will be the Oxide instance name. We could match based on `hostname`, but the query would be much more expensive since we'd have to resort to a List rather than a direct Fetch (View).*

## Testing

1. Turn off CCM (scale to 0)
2. Start Oxide Instance and join to K8s cluster
3. Stop and Delete Oxide Instance
4. Scale up CCM to 1 replica

v0.6.0 the node will continue to exist forever and CCM logs show:

```
node_lifecycle_controller.go:156] error checking if node oxide-w2 exists: failed retrieving instance id from provider id: provider id is empty
``` 

5. Deploy this CCM patch.  The Node resource is deleted since InstanceExists returns false (from name lookup).