### PR TITLE
fix: tolerate `node-role.kubernetes.io/etcd:NoSchedule` taint

### DIFF
--- a/charts/oxide-cloud-controller-manager/templates/deployment.yaml
+++ b/charts/oxide-cloud-controller-manager/templates/deployment.yaml
@@ -22,14 +22,17 @@ spec:
       tolerations:
         - key: "node.cloudprovider.kubernetes.io/uninitialized"
           value: "true"
-          effect: "NoSchedule"
-        - key: "CriticalAddonsOnly"
-          operator: "Exists"
+          effect: NoSchedule
         - key: "node-role.kubernetes.io/control-plane"
           effect: NoSchedule
-        - key: node.kubernetes.io/not-ready
+        - key: "node-role.kubernetes.io/etcd"
           operator: Exists
-          effect: "NoSchedule"
+          effect: NoExecute
+        - key: "node.kubernetes.io/not-ready"
+          operator: Exists
+          effect: NoSchedule
+        - key: CriticalAddonsOnly
+          operator: Exists
       containers:
       - name: {{ include "oxide-ccm.name" . }}
         image: "{{ .Values.deployment.image.name }}:{{ .Values.deployment.image.tag | default .Chart.AppVersion }}"

--- a/manifests/oxide-cloud-controller-manager.yaml
+++ b/manifests/oxide-cloud-controller-manager.yaml
@@ -160,14 +160,17 @@ spec:
       tolerations:
         - key: "node.cloudprovider.kubernetes.io/uninitialized"
           value: "true"
-          effect: "NoSchedule"
-        - key: "CriticalAddonsOnly"
-          operator: "Exists"
+          effect: NoSchedule
         - key: "node-role.kubernetes.io/control-plane"
           effect: NoSchedule
-        - key: node.kubernetes.io/not-ready
+        - key: "node-role.kubernetes.io/etcd"
           operator: Exists
-          effect: "NoSchedule"
+          effect: NoExecute
+        - key: "node.kubernetes.io/not-ready"
+          operator: Exists
+          effect: NoSchedule
+        - key: CriticalAddonsOnly
+          operator: Exists
       containers:
       - name: oxide-cloud-controller-manager
         image: "ghcr.io/oxidecomputer/oxide-cloud-controller-manager:0.7.0"


### PR DESCRIPTION
The CCM deployment now tolerates the
`node-role.kubernetes.io/etcd:NoSchedule` taint, allowing it to schedule on clusters created by Rancher.

Closes SSE-351.